### PR TITLE
Compilation on GHC 7.10 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Put your public API access key and custom search engine id in `conf`.
 6. Change "Search only included sites" to "Search the entire web but emphasize
    included sites"
 7. Click "Search engine ID"
+8. Turn on "Image search"

--- a/jpg-to.cabal
+++ b/jpg-to.cabal
@@ -16,20 +16,25 @@ library
   hs-source-dirs:    src
   exposed-modules:   JpgTo
   default-language:  Haskell2010
-  build-depends:     base >=4.6 && <4.7
-                   , aeson == 0.8.*
-                   , base-prelude == 0.1.*
-                   , lens == 4.*
-                   , lens-aeson == 1.0.0.3
-                   , random >= 1.0.1.1
-                   , text >= 0.11.3.1
-                   , wreq >= 0.1.0.1
+  default-extensions: OverloadedStrings
+                    , NoImplicitPrelude
+  build-depends:     aeson
+                   , base
+                   , base-prelude
+                   , bytestring
+                   , lens
+                   , lens-aeson
+                   , random
+                   , text
+                   , wreq
 
 executable jpg-cli
   main-is:           jpg-cli/Main.hs
   default-language:  Haskell2010
-  build-depends:     base >=4.6 && <4.7
-                   , base-prelude == 0.1.*
+  default-extensions: NoImplicitPrelude
+                    , OverloadedStrings
+  build-depends:     base
+                   , base-prelude
                    , configurator
                    , jpg-to
-                   , text >= 0.11.3.1
+                   , text

--- a/src/JpgTo.hs
+++ b/src/JpgTo.hs
@@ -1,12 +1,10 @@
-{-# LANGUAGE OverloadedStrings, NoImplicitPrelude #-}
-
 module JpgTo
 (
   config
 , findBest
 ) where
 
-import           BasePrelude
+import           BasePrelude hiding ((&))
 import           Control.Lens
 import           Data.Aeson.Lens
 import           Data.Text (Text)


### PR DESCRIPTION
Unfortunately this does break compilation with lower GHC versions, but in a very simple way. If you want to keep your dev boxes on GHC 7.6, I could add a `defined()` check around the `hiding` line.

Note: this is even broken on GHC 7.10 because `wreq` people need to do a release, but you can work around it by cabal installing a clone of their master branch.

Basically this PR is just here for informational purposes. Merge it in when you get 7.10 on your boxes.
