### PR TITLE
Expose a function that just returns the list of links, without sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Put your public API access key and custom search engine id in `conf`.
 6. Change "Search only included sites" to "Search the entire web but emphasize
    included sites"
 7. Click "Search engine ID"
+8. Turn on "Image search"

--- a/jpg-cli/Main.hs
+++ b/jpg-cli/Main.hs
@@ -21,5 +21,5 @@ main = do
       putStrLn "Usage: jpg-cli <query>"
       exitWith $ ExitFailure 1
     query:_ -> do
-      url <- JpgTo.findBest gapi (pack query)
+      url <- JpgTo.luckyLinkOfQuery gapi (pack query)
       putStrLn . unpack . fromJust $ url

--- a/jpg-to.cabal
+++ b/jpg-to.cabal
@@ -16,20 +16,25 @@ library
   hs-source-dirs:    src
   exposed-modules:   JpgTo
   default-language:  Haskell2010
-  build-depends:     base >=4.6 && <4.7
-                   , aeson == 0.8.*
-                   , base-prelude == 0.1.*
-                   , lens == 4.*
-                   , lens-aeson == 1.0.0.3
-                   , random >= 1.0.1.1
-                   , text >= 0.11.3.1
-                   , wreq >= 0.1.0.1
+  default-extensions: OverloadedStrings
+                    , NoImplicitPrelude
+  build-depends:     aeson
+                   , base
+                   , base-prelude
+                   , bytestring
+                   , lens
+                   , lens-aeson
+                   , random
+                   , text
+                   , wreq
 
 executable jpg-cli
   main-is:           jpg-cli/Main.hs
   default-language:  Haskell2010
-  build-depends:     base >=4.6 && <4.7
-                   , base-prelude == 0.1.*
+  default-extensions: NoImplicitPrelude
+                    , OverloadedStrings
+  build-depends:     base
+                   , base-prelude
                    , configurator
                    , jpg-to
-                   , text >= 0.11.3.1
+                   , text

--- a/jpg-to.cabal
+++ b/jpg-to.cabal
@@ -24,7 +24,9 @@ library
                    , bytestring
                    , lens
                    , lens-aeson
-                   , random
+                   , random-fu
+                   , random-extras
+                   , random-source
                    , text
                    , wreq
 

--- a/src/JpgTo.hs
+++ b/src/JpgTo.hs
@@ -1,15 +1,18 @@
 module JpgTo
-(
-  config
-, findBest
+( config
+, linksOfQuery
+, luckyLinkOfQuery
 ) where
+
+import           Data.Random.Extras (safeChoice)
+import           Data.Random.RVar (runRVar)
+import           Data.Random.Source.DevRandom (DevRandom(..))
+import           Data.Text (Text)
+import qualified Network.Wreq as Wreq
 
 import           BasePrelude hiding ((&))
 import           Control.Lens
 import           Data.Aeson.Lens
-import           Data.Text (Text)
-import qualified Network.Wreq as Wreq
-import           System.Random
 
 data Gapi = Gapi { apiKey :: Text, cx :: Text }
 
@@ -29,18 +32,22 @@ imgApiQuery s = (Wreq.param "key" .~ [apiKey s])
 config :: Text -> Text -> Gapi
 config = Gapi
 
-findBest :: Gapi -> Text -> IO (Maybe Text)
-findBest gapi query = do
+linksOfQuery :: Gapi -> Text -> IO [Text]
+linksOfQuery gapi query = do
   let opts = Wreq.defaults
            & imgApiQuery gapi
            & (Wreq.param "q" .~ [query])
   r <- Wreq.getWith opts imgApiRoot
-  let items = toList . (r ^.) $ Wreq.responseBody . key "items" . _Array
-  rand <- randomIO :: IO Int
-  let len = length items
-  if len > 0
-    then do
-      let pick = items !! (rand `mod` len)
-      return . return . (pick ^.) $ key "link" . _String
-    else
-      return Nothing
+  return (r ^.. links)
+  where
+    links =
+      Wreq.responseBody . key "items" . values . key "link" . _String
+
+luckyLinkOfQuery :: Gapi -> Text -> IO (Maybe Text)
+luckyLinkOfQuery gapi query = do
+  links <- linksOfQuery gapi query
+  case safeChoice links of
+   Just link ->
+     Just <$> runRVar link DevRandom
+   Nothing ->
+     return Nothing

--- a/src/JpgTo.hs
+++ b/src/JpgTo.hs
@@ -1,12 +1,10 @@
-{-# LANGUAGE OverloadedStrings, NoImplicitPrelude #-}
-
 module JpgTo
 (
   config
 , findBest
 ) where
 
-import           BasePrelude
+import           BasePrelude hiding ((&))
 import           Control.Lens
 import           Data.Aeson.Lens
 import           Data.Text (Text)


### PR DESCRIPTION
This also switches to using `random-extras` for sampling. Perhaps overkill to bring in a library, but the upside is that you no longer need to keep track of your indices.

This does unfortunately depend on GHC 7.10 ... you can totally ignore these PRs until 7.10 hits Debian/Ubuntu.
