### PR TITLE
Search.hs: export Gapi type

### DIFF
--- a/src/Network/Images/Search.hs
+++ b/src/Network/Images/Search.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings, NoImplicitPrelude #-}
 
 module Network.Images.Search
-( config
+( Gapi(..)
+, config
 , linksOfQuery
 , luckyLinkOfQuery
 ) where


### PR DESCRIPTION
Oops! It was being returned, but you can't reference it. My bad.

in other news, IT'S UM WORKING IN FRIENDSOFJACK.SLACK.COM `/jpeg`
